### PR TITLE
feat(instanceManager): use customer prefix for VM lookup instead of wildcard search

### DIFF
--- a/anx/provider/helpers_test.go
+++ b/anx/provider/helpers_test.go
@@ -22,6 +22,7 @@ type mockedProvider struct {
 	powerControlMock *mocks.PowerControl
 	searchMock       *mocks.Search
 	infoMock         *mocks.Info
+	config           *providerConfig
 }
 
 func getMockedAnxProvider() mockedProvider {
@@ -59,6 +60,15 @@ func (m mockedProvider) VLAN() vlan.API {
 
 func (m mockedProvider) VSphere() vsphere.API {
 	return m.vsphereMock
+}
+
+func (m mockedProvider) Config() *providerConfig {
+	if m.config == nil {
+		return &providerConfig{
+			CustomerPrefix: "no-set",
+		}
+	}
+	return m.config
 }
 
 func providerManagedNode() v1.Node {

--- a/anx/provider/instances.go
+++ b/anx/provider/instances.go
@@ -114,7 +114,7 @@ func (i instanceManager) InstanceIDByNode(ctx context.Context, node *v1.Node) (s
 	if node.Spec.ProviderID != "" {
 		return strings.TrimPrefix(node.Spec.ProviderID, cloudProviderScheme), nil
 	}
-	vms, err := i.VSphere().Search().ByName(ctx, fmt.Sprintf("%%-%s", node.Name)) // TODO check whether this can be implemented without a template
+	vms, err := i.VSphere().Search().ByName(ctx, fmt.Sprintf("%s-%s", i.Config().CustomerPrefix, node.Name))
 	if err != nil {
 		return "", err
 	}

--- a/anx/provider/instances_test.go
+++ b/anx/provider/instances_test.go
@@ -25,7 +25,8 @@ func TestFetchingID(t *testing.T) {
 	t.Run("GetProviderIDForNode/NoProviderID", func(t *testing.T) {
 		t.Parallel()
 		provider := getMockedAnxProvider()
-		provider.searchMock.On("ByName", ctx, fmt.Sprintf("%%-%s", nodeName)).Return([]search.VM{
+		provider.searchMock.On("ByName", ctx, fmt.Sprintf("%s-%s", provider.Config().CustomerPrefix,
+			nodeName)).Return([]search.VM{
 			{
 				Identifier: nodeIdentifier,
 			}}, nil)
@@ -60,7 +61,8 @@ func TestFetchingID(t *testing.T) {
 	t.Run("GetProviderIDForNode/MultipleVMs", func(t *testing.T) {
 		t.Parallel()
 		provider := getMockedAnxProvider()
-		provider.searchMock.On("ByName", ctx, fmt.Sprintf("%%-%s", nodeName)).Return([]search.VM{
+		provider.searchMock.On("ByName", ctx, fmt.Sprintf("%s-%s",
+			provider.Config().CustomerPrefix, nodeName)).Return([]search.VM{
 			{
 				Name:       "VM1",
 				Identifier: nodeIdentifier,

--- a/anx/provider/provider.go
+++ b/anx/provider/provider.go
@@ -24,11 +24,12 @@ type providerConfig struct {
 
 type Provider interface {
 	anexia.API
+	Config() *providerConfig
 }
 
 type anxProvider struct {
 	anexia.API
-	config          providerConfig
+	config          *providerConfig
 	instanceManager instanceManager
 }
 
@@ -40,7 +41,7 @@ func newAnxProvider(config providerConfig) (*anxProvider, error) {
 
 	return &anxProvider{
 		API:    anexia.NewAPI(client),
-		config: config,
+		config: &config,
 	}, nil
 }
 
@@ -79,6 +80,10 @@ func (a anxProvider) ProviderName() string {
 
 func (a anxProvider) HasClusterID() bool {
 	return true
+}
+
+func (a anxProvider) Config() *providerConfig {
+	return a.config
 }
 
 func registerCloudProvider() {

--- a/anx/provider/provider_test.go
+++ b/anx/provider/provider_test.go
@@ -62,3 +62,20 @@ func TestProviderScheme(t *testing.T) {
 	t.Parallel()
 	require.Equal(t, fmt.Sprintf("%s://", cloudProviderName), cloudProviderScheme)
 }
+
+func TestProviderConfig(t *testing.T) {
+	t.Parallel()
+	require.NoError(t, os.Setenv("ANEXIA_TOKEN", "RANDOM_VALUE"))
+	t.Cleanup(func() {
+		require.NoError(t, os.Unsetenv("ANEXIA_TOKEN"))
+	})
+	provider, err := newAnxProvider(providerConfig{
+		"5555",
+	})
+	require.NoError(t, err)
+
+	config := provider.Config()
+
+	require.Equal(t, "5555", config.CustomerPrefix)
+
+}


### PR DESCRIPTION
Instead of executing a wildcard search to find the VM name we now take the customer prefix and perpend it to the host name in order to find the identifier.

