### PR TITLE
Reduce Docker Image Size

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,9 +5,15 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o ccm -ldflags '-s -w'
 
+FROM gruebel/upx:latest as upx
+COPY --from=builder /go/src/github.com/github.com/anexia-it/anxcloud-cloud-controller-manager/ccm /ccm
+
+# Compress the binary and copy it to final image
+RUN upx --best --lzma -o /ccm-small /ccm
+
 FROM alpine:3.14
 EXPOSE 8080
 RUN apk --no-cache add ca-certificates=20191127-r5
 WORKDIR /app/
-COPY --from=builder /go/src/github.com/github.com/anexia-it/anxcloud-cloud-controller-manager/ccm .
+COPY --from=upx /ccm-small ./ccm
 CMD ["/app/ccm", "--cloud-provider=anx"]


### PR DESCRIPTION
Go compiler creates self contained binaries that have no dependencies to other libs on the system. While this is very useful in many cases the binaries tend to get quite big, therefore it became a common practice to use some linker flags (which is already done in this project) or use a binary packing program like `upx`

# Changes

A compression stage is added to the Multi Stage Docker Build. 
This way the DockerImages is only 14MB instead of more than 40MB.

