### PR TITLE
Fix naming of resources

### DIFF
--- a/anx/provider/load_balancer.go
+++ b/anx/provider/load_balancer.go
@@ -112,7 +112,7 @@ func (l loadBalancerManager) UpdateLoadBalancer(ctx context.Context, clusterName
 	lbName := l.GetLoadBalancerName(ctx, clusterName, service)
 	for _, svcPort := range service.Spec.Ports {
 		// first we make sure that the base configuration for the lb exists
-		lbPortName := fmt.Sprintf("%s-%s", lbName, strconv.Itoa(int(svcPort.Port)))
+		lbPortName := fmt.Sprintf("%s.%s", strconv.Itoa(int(svcPort.Port)), lbName)
 		err = lbGroup.EnsureLBConfig(ctx, lbPortName, getNodeEndpoints(nodes, svcPort.NodePort))
 		if err != nil {
 			return err

--- a/anx/provider/loadbalancer/bind.go
+++ b/anx/provider/loadbalancer/bind.go
@@ -55,7 +55,9 @@ func ensureFrontendBindInLoadBalancer(ctx context.Context, lb LoadBalancer, bind
 
 	if existingBind.Frontend.Identifier == string(lb.State.FrontendID) {
 		lb.Logger.Info("frontend changed", "name", bindName, "resource", "bind")
-		updatedBind, err := lb.Bind().Update(ctx, existingBind.Identifier, getBindDefinition(bindName, lb.State))
+		definition := getBindDefinition(bindName, lb.State)
+		definition.State = common.Updating
+		updatedBind, err := lb.Bind().Update(ctx, existingBind.Identifier, definition)
 		return BindID(updatedBind.Identifier), err
 	}
 

--- a/anx/provider/loadbalancer/frontend.go
+++ b/anx/provider/loadbalancer/frontend.go
@@ -61,10 +61,6 @@ func ensureFrontendInLoadBalancer(ctx context.Context, lb LoadBalancer, frontend
 		return createdFrontend, nil
 	}
 
-	//if existingFrontend.DefaultBackend.Identifier != string(lb.State.BackendID) {
-	//
-	//}
-
 	return FrontendID(existingFrontend.Identifier), nil
 }
 


### PR DESCRIPTION
There was an error when updating the LBaas Resources.

Whenever an LBaaS resource was updated, new resources were created with a wrong name, which also lead to misconfigured resources