### PR TITLE
✨🎨: add config for LB prefixes, autodiscover them

### DIFF
--- a/anx/provider/configuration/configuration.go
+++ b/anx/provider/configuration/configuration.go
@@ -2,20 +2,30 @@ package configuration
 
 import (
 	"fmt"
+	"io"
+
 	"github.com/kelseyhightower/envconfig"
 	"gopkg.in/yaml.v3"
-	"io"
 	"k8s.io/cloud-provider/options"
 )
 
 type ProviderConfig struct {
-	Token                            string   `yaml:"anexiaToken" split_words:"true"`
-	CustomerID                       string   `yaml:"customerID,omitempty" split_words:"true"`
-	LoadBalancerIdentifier           string   `yaml:"loadBalancerIdentifier,omitempty" split_words:"true"`
-	ClusterName                      string   `yaml:"clusterName,omitempty" split_words:"true"`
-	AutoDiscoveryTagPrefix           string   `yaml:"autoDiscoveryTagPrefix,omitempty" split_words:"true" default:"anxkube-ccm-lb"`
-	AutoDiscoverLoadBalancer         bool     `yaml:"autoDiscoverLoadBalancer,omitempty" split_words:"true"`
-	SecondaryLoadBalancerIdentifiers []string `yaml:"secondaryLoadBalancersIdentifiers" split_words:"trues"`
+	Token                  string `yaml:"anexiaToken" split_words:"true"`
+	CustomerID             string `yaml:"customerID,omitempty" split_words:"true"`
+	ClusterName            string `yaml:"clusterName,omitempty" split_words:"true"`
+	AutoDiscoveryTagPrefix string `yaml:"autoDiscoveryTagPrefix,omitempty" split_words:"true" default:"anxkube-ccm-lb"`
+
+	// if ccm shall discover $LoadBalancerIdentifier, $SecondaryLoadBalancerIdentifiers and $LoadBalancerPrefixIdentifiers via tag "$AutoDiscoveryTagPrefix-$ClusterName"
+	AutoDiscoverLoadBalancer bool `yaml:"autoDiscoverLoadBalancer,omitempty" split_words:"true"`
+
+	// the LBaaS LoadBalancer resource to configure for LoadBalancer Services
+	LoadBalancerIdentifier string `yaml:"loadBalancerIdentifier,omitempty" split_words:"true"`
+
+	// identifiers of LBaaS LoadBalancer resources to keep in sync with $LoadBalancerIdentifier
+	SecondaryLoadBalancerIdentifiers []string `yaml:"secondaryLoadBalancersIdentifiers" split_words:"true"`
+
+	// lists the identifiers of prefixes from which external IPs for LoadBalancer Services can be allocated
+	LoadBalancerPrefixIdentifiers []string `yaml:"loadBalancerPrefixIdentifiers,omitempty" split_words:"true"`
 }
 
 const (

--- a/anx/provider/discovery/loadbalancer.go
+++ b/anx/provider/discovery/loadbalancer.go
@@ -1,0 +1,94 @@
+package discovery
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"sort"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	corev1 "go.anx.io/go-anxcloud/pkg/apis/core/v1"
+	v1 "go.anx.io/go-anxcloud/pkg/apis/lbaas/v1"
+	"go.anx.io/go-anxcloud/pkg/client"
+	"k8s.io/klog/v2"
+)
+
+func AutoDiscoverLoadBalancer(ctx context.Context, tag string) (string, []string, error) {
+	newAPI, err := api.NewAPI(api.WithClientOptions(client.TokenFromEnv(false)))
+	if err != nil {
+		return "", nil, err
+	}
+
+	var pageIter types.PageInfo
+	err = newAPI.List(ctx, &corev1.Info{
+		Tags: []string{tag},
+	}, api.Paged(1, 100, &pageIter))
+
+	if err != nil {
+		return "", nil, fmt.Errorf("unable to autodiscover load balancer by tag '%s': %w", tag, err)
+	}
+
+	var infos []corev1.Info
+	pageIter.Next(&infos)
+	if pageIter.TotalPages() > 1 {
+		return "", nil, errors.New("too many load balancers were discovered currently only 100")
+	}
+
+	if len(infos) == 0 {
+		return "", nil, errors.New("no load balancers could be discovered")
+	}
+
+	var identifiers []string
+
+	for _, info := range infos {
+		identifiers = append(identifiers, info.Identifier)
+	}
+	sort.Strings(identifiers)
+
+	var secondaryLoadBalancers []string
+
+	if len(identifiers) > 1 {
+		secondaryLoadBalancers = append(secondaryLoadBalancers, identifiers[1:]...)
+	}
+
+	primaryLB := identifiers[0]
+	err = newAPI.Get(ctx, &v1.LoadBalancer{Identifier: primaryLB})
+	if err != nil {
+		klog.Errorf("checking if load balancer '%s' exists returned an error: %s", primaryLB,
+			err.Error())
+		return "", nil, err
+	}
+
+	return primaryLB, secondaryLoadBalancers, nil
+}
+
+func AutoDiscoverLoadBalancerPrefixes(ctx context.Context, tag string) ([]string, error) {
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	genclient, err := api.NewAPI(api.WithClientOptions(client.TokenFromEnv(false)))
+	if err != nil {
+		return nil, fmt.Errorf("error creating generic API client: %w", err)
+	}
+
+	var prefixChannel types.ObjectChannel
+	if err := genclient.List(ctx, &corev1.Info{Tags: []string{tag}}, api.ObjectChannel(&prefixChannel)); err != nil {
+		return nil, fmt.Errorf("error listing resources with tag: %w", err)
+	}
+
+	// most of the time we have one IPv4 and one IPv6 prefix, optimize for that case
+	ret := make([]string, 0, 2)
+
+	for retriever := range prefixChannel {
+		var prefix corev1.Info
+		if err := retriever(&prefix); err != nil {
+			cancel()
+			return nil, fmt.Errorf("error retrieving resource: %w", err)
+		}
+
+		ret = append(ret, prefix.Identifier)
+	}
+
+	return ret, nil
+}


### PR DESCRIPTION
Adds configuration for external network prefixes which can be used to
allocate LoadBalancer IPs from. Also adds autodiscovery via tags,
with a currently not configurable format.

Moves the LoadBalancer autodiscovery stuff into anx/provider/discovery
to enhance code structure.

Tested this by adding a minimal implementation of "correct externalIP on kubernetes services", which I'll work on after this is merged.