### PR TITLE
:recycle: :loud_sound:: Replace panics by log and return (SYSENG-964)

### DIFF
--- a/anx/controller/lbaas/sync/replication/replication.go
+++ b/anx/controller/lbaas/sync/replication/replication.go
@@ -220,7 +220,7 @@ func FetchLoadBalancer(ctx context.Context, lbID string, anxAPI api.API) (compon
 				var s server.Server
 				err := receiver(&s)
 				if err != nil {
-					logger.Error(err, "could not iterate over fetched servers")
+					logger.Error(err, "could not retrieve server for backend")
 					return
 				}
 				hashedServer := components.NewHashedServer(s)
@@ -256,7 +256,7 @@ func FetchLoadBalancer(ctx context.Context, lbID string, anxAPI api.API) (compon
 				var fb bind.Bind
 				err := receiver(&fb)
 				if err != nil {
-					logger.Error(err, "could not iterate over frontend binds")
+					logger.Error(err, "could not retrieve frontend bind for frontend")
 					return
 				}
 				hashedBind := components.NewHashedBind(fb)


### PR DESCRIPTION
It can happen that an error occurs during the sync. The replication controller is currently not caring much about this, sinc it will probably be healed over time. Therefore a panic during one of these syncs might not be the perfect response to an error. 

## Changes

* Replace panics by logging the error and return. 

