### PR TITLE
💩✨🐛: store correct LoadBalancer IP in service (SYSENG-922)

### DIFF
--- a/anx/controller/lbaas/sync/sync.go
+++ b/anx/controller/lbaas/sync/sync.go
@@ -4,6 +4,9 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"sync"
+	"time"
+
 	"github.com/anexia-it/anxcloud-cloud-controller-manager/anx/controller/lbaas/sync/components"
 	"github.com/anexia-it/anxcloud-cloud-controller-manager/anx/controller/lbaas/sync/replication"
 	"github.com/go-logr/logr"
@@ -17,8 +20,6 @@ import (
 	"k8s.io/controller-manager/controller"
 	"k8s.io/klog/v2"
 	"k8s.io/klog/v2/klogr"
-	"sync"
-	"time"
 )
 
 type syncController struct {
@@ -68,6 +69,7 @@ func startSyncController(ctx app.ControllerInitContext, stop <-chan struct{},
 	replicationManager, ok := replicationProvider.Replication()
 	if !ok {
 		klog.Info("The provider does not support lbaas replication. Skipping lbaas replication")
+		return nil, false, nil
 	}
 
 	client := config.ClientBuilder.ClientOrDie(ctx.ClientName)

--- a/anx/provider/ipcalc.go
+++ b/anx/provider/ipcalc.go
@@ -1,0 +1,47 @@
+// XXX: nuke this file when we can add and delete LoadBalancer IPs, which is not the case
+// for Anexia Kubernetes Service MVP
+// I'm seriously surprised "get nth address of network" isn't in Go's standard library o.o
+// -- Mara @LittleFox94 Grosch, 2022-02-18
+
+package provider
+
+import (
+	"net"
+)
+
+// calculateVIP calculates the IP address before the broadcast address of a given network, which is
+// the one virtual IP we currently configure on the LoadBalancer VMs.
+func calculateVIP(n net.IPNet) net.IP {
+	net, size := n.Mask.Size()
+	ret := n.IP
+
+	// we iterate through the address byte by byte
+	for i := 0; i < size/8; i++ {
+		n := net - i*8
+		byteMask := bitMaskForN(n)
+
+		// "set all host bits to one"
+		ret[i] |= ^byteMask
+	}
+
+	// set LSB of address to zero, resulting in the address below the broadcast address of the network
+	ret[len(ret)-1] -= 1
+
+	return ret
+}
+
+// bitMaskForN generates a bit mask with the given number of bits set, starting from MSB.
+func bitMaskForN(n int) byte {
+	if n >= 8 {
+		return 0xFF
+	}
+
+	var ret byte = 0
+
+	for n > 0 {
+		ret |= 1 << (8 - n)
+		n--
+	}
+
+	return ret
+}

--- a/anx/provider/ipcalc_test.go
+++ b/anx/provider/ipcalc_test.go
@@ -1,0 +1,79 @@
+package provider
+
+import (
+	"fmt"
+	"net"
+	"testing"
+)
+
+func TestIPCalc(t *testing.T) {
+	testcases := map[string]string{
+		"10.0.0.0/8":        "10.255.255.254",
+		"10.1.0.0/16":       "10.1.255.254",
+		"10.1.2.0/24":       "10.1.2.254",
+		"10.1.2.192/26":     "10.1.2.254",
+		"10.1.2.192/27":     "10.1.2.222",
+		"172.20.239.128/26": "172.20.239.190",
+
+		"fda0:23:1f05:42::/64": "fda0:23:1f05:42:ffff:ffff:ffff:fffe",
+		"2001:db8:42:34::/64":  "2001:db8:42:34:ffff:ffff:ffff:fffe",
+		"2001:db8:42:34::/80":  "2001:db8:42:34::ffff:ffff:fffe",
+		"2001:db8:42:34::/96":  "2001:db8:42:34::ffff:fffe",
+		"2001:db8:42:34::/97":  "2001:db8:42:34::7fff:fffe",
+		"2001:db8:42:34::/98":  "2001:db8:42:34::3fff:fffe",
+		"2001:db8:42:34::/99":  "2001:db8:42:34::1fff:fffe",
+		"2001:db8:42:34::/100": "2001:db8:42:34::fff:fffe",
+		"2001:db8:42:34::/112": "2001:db8:42:34::fffe",
+		"2001:db8:42:34::/124": "2001:db8:42:34::e",
+	}
+
+	for cidr, exp := range testcases {
+		_, n, err := net.ParseCIDR(cidr)
+		if err != nil {
+			panic(fmt.Errorf("error parsing testcase CIDR: %w", err))
+		}
+
+		ip := net.ParseIP(exp)
+
+		vip := calculateVIP(*n)
+		if !vip.Equal(ip) {
+			t.Errorf("VIP %q does not match expected %q", vip.String(), exp)
+		}
+	}
+}
+
+func TestBitmaskForN(t *testing.T) {
+	testcases := []byte{
+		0,
+		0x80,
+		0xc0,
+		0xe0,
+		0xf0,
+		0xf8,
+		0xfc,
+		0xfe,
+		0xff,
+
+		// some more cases each returning 0xFF as prefix len > 8
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+		0xff,
+	}
+
+	for n, expMask := range testcases {
+		mask := bitMaskForN(n)
+
+		if mask != expMask {
+			t.Errorf("bitMaskForN(%d) result %x does not match expected mask %x", n, mask, expMask)
+		}
+	}
+}

--- a/anx/provider/loadbalancer/loadbalancer.go
+++ b/anx/provider/loadbalancer/loadbalancer.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	fmt "fmt"
+
 	"github.com/go-logr/logr"
 	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/client"
@@ -210,12 +211,4 @@ func (g LoadBalancer) GetProvisioningState(ctx context.Context, lbName string) (
 type HostInformation struct {
 	IP       string
 	Hostname string
-}
-
-func GetHostInformation(ctx context.Context, lbaasClient lbaas.API, id string) (HostInformation, error) {
-	fetchedBalancer, err := lbaasClient.LoadBalancer().GetByID(ctx, id)
-	return HostInformation{
-		IP:       fetchedBalancer.IpAddress,
-		Hostname: "",
-	}, err
 }

--- a/anx/provider/provider.go
+++ b/anx/provider/provider.go
@@ -13,6 +13,7 @@ import (
 
 	anexia "go.anx.io/go-anxcloud/pkg"
 	anxClient "go.anx.io/go-anxcloud/pkg/client"
+
 	cloudprovider "k8s.io/cloud-provider"
 	"k8s.io/klog/v2"
 )
@@ -90,7 +91,7 @@ func (a *anxProvider) Initialize(builder cloudprovider.ControllerClientBuilder, 
 		}
 	}
 
-	a.loadBalancerManager = newLoadBalancerManager(a)
+	a.loadBalancerManager = newLoadBalancerManager(a, builder)
 
 	if a.isLBaaSReplicationEnabled() {
 		a.loadBalancerManager.notify = make(chan struct{}, 1)


### PR DESCRIPTION
This determines the correct external LoadBalancer IP from the discovered
prefixes, doing some black magic IP calculation. The code is prepared to
allocate new addresses and even prefixes, with lots of comments which
code is MVP-only and has to be nuked later (like the black magic IP
calculation).

Also checks if another Service in the cluster already uses the one
usable LoadBalancer IP and returns an error, which is added as event to
the Service, making it visible for the customer.

# Changes

* determine and store correct external IP for LoadBalancer services
* fixes a bug where LBaaS syncing was detected as not supported but still enabled, resulting in lots of errors being logged