### PR TITLE
SYSENG-1226 🩹: Adapt dev run script to new cluster names

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Requires a Go (>= 1.17) toolchain and `make`. For compiling and testing, use the
 `run` and `debug`, but you need some more setup first:
 
 * create API key for Anexia Engine
-* create cluster in Anexia Kubernetes Service and retrieve its identifier (last part of the URL of its detail page)
+* create cluster in Anexia Kubernetes Service
 * copy `envrc-sample` to `.envrc`, fill your values and run `direnv allow`
-  - alternatively, you can export `ANEXIA_TOKEN` with your token and `ANXKUBE_CLUSTER_IDENTIFIER` with your cluster identifier
+  - alternatively, you can export `ANEXIA_TOKEN` with your token and `KKP_HUMAN_READABLE_NAME` with your cluster's name
 
 Interactive debugging requires [`delve`](https://github.com/go-delve/delve) to be installed in path.
 

--- a/envrc-sample
+++ b/envrc-sample
@@ -1,2 +1,2 @@
-export ANXKUBE_CLUSTER_IDENTIFIER=Engine identifier of the cluster to run CCM against
+export KKP_HUMAN_READABLE_NAME=Human readable name of the cluster in KKP. For an Anexia Kubernetes Service cluster, that's its name in the Engine.
 export ANEXIA_TOKEN=your Anexia API token

--- a/hack/anxkube-dev-run
+++ b/hack/anxkube-dev-run
@@ -5,8 +5,8 @@ log() {
 }
 
 check_dependencies() {
-    if [ -z "$ANXKUBE_CLUSTER_IDENTIFIER" ]; then
-        log "Please configure your cluster via ANXKUBE_CLUSTER_IDENTIFIER"
+    if [ -z "$KKP_HUMAN_READABLE_NAME" ]; then
+        log "Please configure your cluster via its KKP_HUMAN_READABLE_NAME. For an Anexia Kubernetes Service cluster, that's its name in the Engine"
         exit 1
     fi
 
@@ -41,7 +41,7 @@ check_config() {
 retrieve_configs() {
     kkp_cluster_id=$(
         $KUBECTL get cluster -o json |
-        $JQ -r ".items[]|select(.spec.humanReadableName == \"$ANXKUBE_CLUSTER_IDENTIFIER\")|.metadata.name"
+        $JQ -r ".items[]|select(.spec.humanReadableName == \"$KKP_HUMAN_READABLE_NAME\")|.metadata.name"
     )
 
     if [ -z "$kkp_cluster_id" ]; then


### PR DESCRIPTION
We're not using Engine identifiers in KKP anymore, so this makes the dev run script use a more universal config variable.