### PR TITLE
SYSENG-1215 🐛: configure health check on LBaaS Backend

### DIFF
--- a/anx/provider/loadbalancer/reconciliation/reconciliation.go
+++ b/anx/provider/loadbalancer/reconciliation/reconciliation.go
@@ -552,6 +552,7 @@ func (r *reconciliation) reconcileBackends() (toCreate, toDestroy []types.Object
 			Name:         r.makeResourceName(name),
 			LoadBalancer: lbaasv1.LoadBalancer{Identifier: r.lb.Identifier},
 			Mode:         lbaasv1.TCP,
+			HealthCheck:  `"adv_check": "tcp-check"`,
 		})
 	}
 
@@ -561,7 +562,7 @@ func (r *reconciliation) reconcileBackends() (toCreate, toDestroy []types.Object
 	err = compare.Reconcile(
 		targetBackends, r.backends,
 		&toCreate, &toDestroy,
-		"Name", "Mode", "LoadBalancer.Identifier",
+		"Name", "Mode", "HealthCheck", "LoadBalancer.Identifier",
 	)
 	if err != nil {
 		return nil, nil, err

--- a/anx/provider/loadbalancer/reconciliation/reconciliation_test.go
+++ b/anx/provider/loadbalancer/reconciliation/reconciliation_test.go
@@ -193,12 +193,14 @@ var _ = Describe("reconcile", func() {
 			httpBackendIdentifier = mock.FakeExisting(&lbaasv1.Backend{
 				Name:         "http." + testClusterName,
 				Mode:         lbaasv1.TCP,
+				HealthCheck:  `"adv_check": "tcp-check"`,
 				LoadBalancer: lbaasv1.LoadBalancer{Identifier: testLoadBalancerIdentifier},
 			}, fmt.Sprintf("anxccm-svc-uid=%v", svcUID))
 
 			httpsBackendIdentifier = mock.FakeExisting(&lbaasv1.Backend{
 				Name:         "https." + testClusterName,
 				Mode:         lbaasv1.TCP,
+				HealthCheck:  `"adv_check": "tcp-check"`,
 				LoadBalancer: lbaasv1.LoadBalancer{Identifier: testLoadBalancerIdentifier},
 			}, fmt.Sprintf("anxccm-svc-uid=%v", svcUID))
 
@@ -351,12 +353,14 @@ var _ = Describe("reconcile", func() {
 			httpBackendIdentifier = mock.FakeExisting(&lbaasv1.Backend{
 				Name:         "http." + testClusterName,
 				Mode:         lbaasv1.TCP,
+				HealthCheck:  `"adv_check": "tcp-check"`,
 				LoadBalancer: lbaasv1.LoadBalancer{Identifier: testLoadBalancerIdentifier},
 			}, fmt.Sprintf("anxccm-svc-uid=%v", svcUID))
 
 			httpsBackendIdentifier = mock.FakeExisting(&lbaasv1.Backend{
 				Name:         "https." + testClusterName,
 				Mode:         lbaasv1.TCP,
+				HealthCheck:  `"adv_check": "tcp-check"`,
 				LoadBalancer: lbaasv1.LoadBalancer{Identifier: testLoadBalancerIdentifier},
 			}, fmt.Sprintf("anxccm-svc-uid=%v", svcUID))
 

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/prometheus/client_golang v1.12.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.7.1
-	go.anx.io/go-anxcloud v0.4.2
+	go.anx.io/go-anxcloud v0.4.3
 	gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b
 	k8s.io/api v0.23.6
 	k8s.io/apimachinery v0.23.6

--- a/go.sum
+++ b/go.sum
@@ -160,10 +160,11 @@ github.com/go-logfmt/logfmt v0.5.0/go.mod h1:wCYkCAKZfumFQihp8CzCvQ3paCTfi41vtzG
 github.com/go-logr/logr v0.1.0/go.mod h1:ixOQHD9gLJUVQQ2ZOR7zLEifBX6tGkNJF4QyIY7sIas=
 github.com/go-logr/logr v0.2.0/go.mod h1:z6/tIYblkpsD+a4lm/fGIIU9mZ+XfAiaFtq7xTgseGU=
 github.com/go-logr/logr v1.2.0/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
+github.com/go-logr/logr v1.2.2/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
 github.com/go-logr/logr v1.2.3 h1:2DntVwHkVopvECVRSlL5PSo9eG+cAkDCuckLubN+rq0=
 github.com/go-logr/logr v1.2.3/go.mod h1:jdQByPbusPIv2/zmleS9BjJVeZ6kBagPoEUsqbVz/1A=
-github.com/go-logr/stdr v1.2.0 h1:j4LrlVXgrbIWO83mmQUnK0Hi+YnbD+vzrE1z/EphbFE=
-github.com/go-logr/stdr v1.2.0/go.mod h1:YkVgnZu1ZjjL7xTxrfm/LLZBfkhTqSR1ydtm6jTKKwI=
+github.com/go-logr/stdr v1.2.2 h1:hSWxHoqTgW2S2qGc0LTAI563KZ5YKYRhT3MFKZMbjag=
+github.com/go-logr/stdr v1.2.2/go.mod h1:mMo/vtBO5dYbehREoey6XUKy/eSumjCCveDpRre4VKE=
 github.com/go-logr/zapr v1.2.0/go.mod h1:Qa4Bsj2Vb+FAVeAKsLD8RLQ+YRJB8YDmOAKxaBQf7Ro=
 github.com/go-openapi/jsonpointer v0.19.3/go.mod h1:Pl9vOtqEWErmShwVjC8pYs9cog34VGT37dQOVbmoatg=
 github.com/go-openapi/jsonpointer v0.19.5 h1:gZr+CIYByUqjcgeLXnQu2gHYQC9o73G2XUeOFYEICuY=
@@ -378,7 +379,6 @@ github.com/onsi/ginkgo v1.12.1/go.mod h1:zj2OWP4+oCPe1qIXoGWkgMRwljMUYCdkwsT2108
 github.com/onsi/ginkgo v1.14.0/go.mod h1:iSB4RoI2tjJc9BBv4NKIKWKya62Rps+oPG/Lv9klQyY=
 github.com/onsi/ginkgo v1.16.4 h1:29JGrr5oVBm5ulCWet69zQkzWipVXIol6ygQUe/EzNc=
 github.com/onsi/ginkgo v1.16.4/go.mod h1:dX+/inL/fNMqNlz0e9LfyB9TswhZpCVdJM/Z6Vvnwo0=
-github.com/onsi/ginkgo/v2 v2.0.0/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.3/go.mod h1:vw5CSIxN1JObi/U8gcbwft7ZxR2dgaR70JSE3/PpL4c=
 github.com/onsi/ginkgo/v2 v2.1.4 h1:GNapqRSid3zijZ9H77KrgVG4/8KqiyRsxcSxe+7ApXY=
 github.com/onsi/ginkgo/v2 v2.1.4/go.mod h1:um6tUpWM/cxCK3/FK8BXqEiUMUwRgSM4JXG47RKZmLU=
@@ -493,8 +493,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.0/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 github.com/yuin/goldmark v1.4.1/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.anx.io/go-anxcloud v0.4.2 h1:+/snGC50r1Csa1GvG4lZFZIuIdbVEXoxAE2uQ/cKuJs=
-go.anx.io/go-anxcloud v0.4.2/go.mod h1:6ODWdaHvPBB0heOL9hqymgs1YSNwcUJ2LyammAYJFsI=
+go.anx.io/go-anxcloud v0.4.3 h1:dvaBjg870dkjlrVZeRu27WYgOjvb/YFKit8eT5Q/yHc=
+go.anx.io/go-anxcloud v0.4.3/go.mod h1:rzQ48vxTWBgS62zNvaJlVfqZfySBBhNcY++rR+MVrPI=
 go.etcd.io/bbolt v1.3.2/go.mod h1:IbVyRI1SCnLcuJnV2u8VeU0CEYM7e686BmAb1XKL+uU=
 go.etcd.io/bbolt v1.3.6 h1:/ecaJf0sk1l4l6V4awd65v2C3ILy7MSj+s/x1ADCIMU=
 go.etcd.io/bbolt v1.3.6/go.mod h1:qXsaaIqmgQH0T+OPdb99Bf+PKfBBQVAdyD6TY9G8XM4=


### PR DESCRIPTION
We are only creating LBaaS resources for TCP services but didn't
configure the HealthCheck attribute on Backend resources, resulting in
the default HTTP check being used.

Updates go-anxcloud to v0.4.3 to include a bugfix we need for this.