### PR TITLE
Wait for already existing but progressing LBaaS resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ Please add your changelog entry under this comment in the correct category (Secu
 
 ### Changes
 * upgrade to Go 1.18 @LittleFox94 (#94)
+* handle already existing LBaaS resources that are still progressing @LittleFox94 (#93)
 
 ## [1.4.1] - 2022-05-04
 

--- a/anx/provider/loadbalancer/reconciliation/lbaas_mock_test.go
+++ b/anx/provider/loadbalancer/reconciliation/lbaas_mock_test.go
@@ -3,6 +3,7 @@ package reconciliation
 import (
 	"reflect"
 	"sort"
+	"sync"
 
 	"go.anx.io/go-anxcloud/pkg/api"
 	"go.anx.io/go-anxcloud/pkg/api/types"
@@ -31,6 +32,8 @@ type lbaasMockServer struct {
 
 	identifierToResource map[string]reflect.Value
 	tags                 map[string][]string
+
+	mutex sync.Mutex
 }
 
 func lbaasMockAPI() (api.API, LBaaSMock) {
@@ -42,6 +45,8 @@ func lbaasMockAPI() (api.API, LBaaSMock) {
 
 		identifierToResource: make(map[string]reflect.Value),
 		tags:                 make(map[string][]string),
+
+		mutex: sync.Mutex{},
 	}
 
 	return &ms, &ms

--- a/anx/provider/loadbalancer/reconciliation/object_stringer.go
+++ b/anx/provider/loadbalancer/reconciliation/object_stringer.go
@@ -1,0 +1,48 @@
+package reconciliation
+
+import (
+	"errors"
+	"fmt"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+)
+
+func stringifyObject(o types.Object) (string, error) {
+	identifier, err := types.GetObjectIdentifier(o, true)
+	if err != nil && errors.Is(err, types.ErrUnidentifiedObject) {
+		identifier = "<no identifier>"
+	} else if err != nil {
+		return "", err
+	}
+
+	return fmt.Sprintf("%T:%v", o, identifier), nil
+}
+
+func stringifyObjects(os []types.Object) ([]string, error) {
+	ret := make([]string, 0, len(os))
+	for _, o := range os {
+		s, err := stringifyObject(o)
+		if err != nil {
+			return nil, err
+		}
+
+		ret = append(ret, s)
+	}
+	return ret, nil
+}
+
+func mustStringifyObject(o types.Object) string {
+	ret, err := stringifyObject(o)
+	if err != nil {
+		panic(fmt.Errorf("stringifyObject failed in mustStringifyObject: %w", err))
+	}
+	return ret
+}
+
+func mustStringifyObjects(os []types.Object) []string {
+	ret, err := stringifyObjects(os)
+	if err != nil {
+		panic(fmt.Errorf("stringifyObjects failed in mustStringifyObjects: %w", err))
+	}
+	return ret
+}

--- a/anx/provider/loadbalancer/reconciliation/reconcile_backends.go
+++ b/anx/provider/loadbalancer/reconciliation/reconcile_backends.go
@@ -1,0 +1,49 @@
+package reconciliation
+
+import (
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/object/compare"
+
+	lbaasv1 "go.anx.io/go-anxcloud/pkg/apis/lbaas/v1"
+)
+
+const backendResourceTypeIdentifier = "33164a3066a04a52be43c607f0c5dd8c"
+
+func (r *reconciliation) reconcileBackends() (toCreate, toDestroy []types.Object, err error) {
+	targetBackends := make([]*lbaasv1.Backend, 0, len(r.ports))
+	for name := range r.ports {
+		targetBackends = append(targetBackends, &lbaasv1.Backend{
+			Name:         r.makeResourceName(name),
+			LoadBalancer: lbaasv1.LoadBalancer{Identifier: r.lb.Identifier},
+			Mode:         lbaasv1.TCP,
+			HealthCheck:  `"adv_check": "tcp-check"`,
+		})
+	}
+
+	toCreate = make([]types.Object, 0, len(targetBackends))
+	toDestroy = make([]types.Object, 0, len(r.backends))
+
+	err = compare.Reconcile(
+		targetBackends, r.backends,
+		&toCreate, &toDestroy,
+		"Name", "Mode", "HealthCheck", "LoadBalancer.Identifier",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(toCreate) == 0 && len(toDestroy) == 0 {
+		for name := range r.ports {
+			expectedName := r.makeResourceName(name)
+
+			for _, b := range targetBackends {
+				if b.Name == expectedName {
+					r.portBackends[name] = b
+					break
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/anx/provider/loadbalancer/reconciliation/reconcile_binds.go
+++ b/anx/provider/loadbalancer/reconciliation/reconcile_binds.go
@@ -1,0 +1,83 @@
+package reconciliation
+
+import (
+	"fmt"
+	"sort"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/object/compare"
+
+	lbaasv1 "go.anx.io/go-anxcloud/pkg/apis/lbaas/v1"
+)
+
+const bindResourceTypeIdentifier = "bd24def982aa478fb3352cb5f49aab47"
+
+func (r *reconciliation) storePublicAddress(addr string) {
+	if idx := sort.SearchStrings(r.publicAddresses, addr); idx >= len(r.publicAddresses) || r.publicAddresses[idx] != addr {
+		r.publicAddresses = append(r.publicAddresses, addr)
+		sort.Strings(r.publicAddresses)
+	}
+}
+
+func (r *reconciliation) filterBinds(allBinds []*lbaasv1.Bind) ([]*lbaasv1.Bind, error) {
+	ret := make([]*lbaasv1.Bind, 0, len(allBinds))
+
+	// Binds and Servers are filtered for our LoadBalancer here, after we hopefully retrieved their Frontends and Backends already
+	for _, bind := range allBinds {
+		idx, err := compare.Search(lbaasv1.Frontend{Identifier: bind.Frontend.Identifier}, r.frontends, "Identifier")
+		if err != nil {
+			return nil, fmt.Errorf("error checking if Binds belongs to one of our frontends: %w", err)
+		} else if idx != -1 {
+			ret = append(ret, bind)
+			r.sortObjectIntoStateArray(bind)
+
+			if bind.Address != "" {
+				r.storePublicAddress(bind.Address)
+			}
+		}
+	}
+
+	return ret, nil
+}
+
+func (r *reconciliation) reconcileBinds() (toCreate, toDestroy []types.Object, err error) {
+	targetBinds := make([]*lbaasv1.Bind, 0, len(r.externalAddresses)*len(r.ports))
+	for _, a := range r.externalAddresses {
+		fam := "v6"
+
+		if a.To4() != nil {
+			fam = "v4"
+		}
+
+		for name, port := range r.ports {
+			frontend, ok := r.portFrontends[name]
+			if !ok {
+				r.logger.V(2).Info("Not reconciling bind because frontend not (yet?) found",
+					"address", a,
+					"port", name,
+				)
+				continue
+			}
+			targetBinds = append(targetBinds, &lbaasv1.Bind{
+				Name:     r.makeResourceName(fam, name),
+				Address:  a.String(),
+				Port:     int(port.External),
+				Frontend: lbaasv1.Frontend{Identifier: frontend.Identifier},
+			})
+		}
+	}
+
+	toCreate = make([]types.Object, 0, len(targetBinds))
+	toDestroy = make([]types.Object, 0, len(r.binds))
+
+	err = compare.Reconcile(
+		targetBinds, r.binds,
+		&toCreate, &toDestroy,
+		"Name", "Address", "Port", "Frontend.Identifier",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return
+}

--- a/anx/provider/loadbalancer/reconciliation/reconcile_frontends.go
+++ b/anx/provider/loadbalancer/reconciliation/reconcile_frontends.go
@@ -1,0 +1,57 @@
+package reconciliation
+
+import (
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/object/compare"
+
+	lbaasv1 "go.anx.io/go-anxcloud/pkg/apis/lbaas/v1"
+)
+
+const frontendResourceTypeIdentifier = "da9d14b9d95840c08213de67f9cee6e2"
+
+func (r *reconciliation) reconcileFrontends() (toCreate, toDestroy []types.Object, err error) {
+	targetFrontends := make([]*lbaasv1.Frontend, 0, len(r.ports))
+	for name := range r.ports {
+		backend, ok := r.portBackends[name]
+		if !ok {
+			r.logger.V(2).Info("Not reconciling frontend because backend not (yet?) found",
+				"port", name,
+			)
+			continue
+		}
+
+		targetFrontends = append(targetFrontends, &lbaasv1.Frontend{
+			Name:           r.makeResourceName(name),
+			Mode:           lbaasv1.TCP,
+			LoadBalancer:   &lbaasv1.LoadBalancer{Identifier: r.lb.Identifier},
+			DefaultBackend: &lbaasv1.Backend{Identifier: backend.Identifier},
+		})
+	}
+
+	toCreate = make([]types.Object, 0, len(targetFrontends))
+	toDestroy = make([]types.Object, 0, len(r.frontends))
+
+	err = compare.Reconcile(
+		targetFrontends, r.frontends,
+		&toCreate, &toDestroy,
+		"Name", "Mode", "LoadBalancer.Identifier", "DefaultBackend.Identifier",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if len(toCreate) == 0 && len(toDestroy) == 0 {
+		for name := range r.ports {
+			expectedName := r.makeResourceName(name)
+
+			for _, f := range targetFrontends {
+				if f.Name == expectedName {
+					r.portFrontends[name] = f
+					break
+				}
+			}
+		}
+	}
+
+	return
+}

--- a/anx/provider/loadbalancer/reconciliation/reconcile_servers.go
+++ b/anx/provider/loadbalancer/reconciliation/reconcile_servers.go
@@ -1,0 +1,66 @@
+package reconciliation
+
+import (
+	"fmt"
+
+	"go.anx.io/go-anxcloud/pkg/api/types"
+	"go.anx.io/go-anxcloud/pkg/utils/object/compare"
+
+	lbaasv1 "go.anx.io/go-anxcloud/pkg/apis/lbaas/v1"
+)
+
+const serverResourceTypeIdentifier = "01f321a4875446409d7d8469503a905f"
+
+func (r *reconciliation) filterServers(allServers []*lbaasv1.Server) ([]*lbaasv1.Server, error) {
+	ret := make([]*lbaasv1.Server, 0, len(allServers))
+
+	for _, server := range allServers {
+		idx, err := compare.Search(lbaasv1.Backend{Identifier: server.Backend.Identifier}, r.backends, "Identifier")
+		if err != nil {
+			return nil, fmt.Errorf("error checking if Server belongs to one of our frontends: %w", err)
+		} else if idx != -1 {
+			ret = append(ret, server)
+			r.sortObjectIntoStateArray(server)
+		}
+	}
+
+	return ret, nil
+}
+
+func (r *reconciliation) reconcileServers() (toCreate, toDestroy []types.Object, err error) {
+	targetServers := make([]*lbaasv1.Server, 0, len(r.ports)*len(r.targetServers))
+	for _, server := range r.targetServers {
+		for portName, port := range r.ports {
+			backend, ok := r.portBackends[portName]
+			if !ok {
+				r.logger.V(2).Info("Not reconciling server because backend not (yet?) found",
+					"server", server.Name,
+					"port", portName,
+				)
+				continue
+			}
+
+			targetServers = append(targetServers, &lbaasv1.Server{
+				Name:    r.makeResourceName(server.Name, portName),
+				IP:      server.Address.String(),
+				Port:    int(port.Internal),
+				Check:   "enabled",
+				Backend: lbaasv1.Backend{Identifier: backend.Identifier},
+			})
+		}
+	}
+
+	toCreate = make([]types.Object, 0, len(targetServers))
+	toDestroy = make([]types.Object, 0, len(r.servers))
+
+	err = compare.Reconcile(
+		targetServers, r.servers,
+		&toCreate, &toDestroy,
+		"Name", "IP", "Port", "Check", "Backend.Identifier",
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return
+}


### PR DESCRIPTION
When retrieving existing Object that are not yet ready, we now wait for them in Reconcile() before doing anything else

This also does some code reformatting and cleanup.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References
* [ANXKUBE-234](https://ats.anexia-it.com/browse/ANXKUBE-234)

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
