### PR TITLE
Upgrade to Go 1.19 for building and Alpine 3.16 for runtime

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -10,7 +10,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@v2
         with:
-         go-version: '1.18'
+         go-version: '1.19'
 
       - name: check if go.mod and go.sum are tidy
         run: make depscheck

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -12,7 +12,7 @@ jobs:
 
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
 
       - uses: paambaati/codeclimate-action@v3.0.0
         env:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -59,10 +59,13 @@ jobs:
     if: "github.actor != 'dependabot[bot]'"
     needs: [build]
     steps:
+      - uses: actions/checkout@v2
+
       - name: Get Image Tag
         run: echo "::set-output name=tag::sha-${GITHUB_SHA::7}"
         shell: bash
         id: git
+
       - name: Run Trivy vulnerability scanner
         uses: aquasecurity/trivy-action@master
         with:
@@ -72,6 +75,7 @@ jobs:
           ignore-unfixed: true
           vuln-type: 'os,library'
           severity: 'CRITICAL,HIGH'
+          trivyignores: .trivyignore
 
   docs:
     runs-on: ubuntu-latest

--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,4 @@
+# security issue in a package we indirectly depend on via kubernetes packages
+# we cannot change anything here, but this entry can be removed once the matching issue in 
+# kubernetes itself (https://github.com/kubernetes/kubernetes/issues/110338) is fixed
+CVE-2022-1996

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Changes
+* k8s-anexia-ccm is now built with Go 1.19 @LittleFox94 (#111)
+
 ## [1.4.3]
 
 ### Fixes

--- a/anx/provider/loadbalancer/reconciliation/reconciliation.go
+++ b/anx/provider/loadbalancer/reconciliation/reconciliation.go
@@ -86,11 +86,11 @@ type reconciliation struct {
 
 // New creates a new Reconcilation instance, usable to reconcile Anexia LBaaS resources for
 //
-//  * a single LBaaS LoadBalancer
-//  * a single service UID (used for tagging the created resources and listing them)
-//  * a set of external IP addresses (translated into LBaaS Binds)
-//  * a set of ports (each having an internal (Kubernetes NodePort) and external (LBaaS Bind) port)
-//  * a set of nodes (each translated to a LBaaS Server)
+//   - a single LBaaS LoadBalancer
+//   - a single service UID (used for tagging the created resources and listing them)
+//   - a set of external IP addresses (translated into LBaaS Binds)
+//   - a set of ports (each having an internal (Kubernetes NodePort) and external (LBaaS Bind) port)
+//   - a set of nodes (each translated to a LBaaS Server)
 //
 // Before doing anything, it will list all resources currently present in the Engine tagged with
 // `anxccm-svc-ui=$serviceUID`.


### PR DESCRIPTION
Unpins the version of ca-certificates in the runtime image. This was pinned by a nitpick from hadolint, which does no good in this specific case. I disable the warning and added a comment about it.

I also added a `.trivyignore` file to ignore the one CVE we cannot do anything about, see the comment I added for that as well.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

* the failing docker builds in CI

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
