### PR TITLE
Properly handle incomplete provider initialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Fixed
+* Properly handle uninitialized optional features @marioreggiori (#120)
+
 ### Changes
 * k8s-anexia-ccm is now built with Go 1.19 @LittleFox94 (#111)
 

--- a/anx/provider/provider.go
+++ b/anx/provider/provider.go
@@ -121,6 +121,10 @@ func (a *anxProvider) initializeLoadBalancerManager(builder cloudprovider.Contro
 }
 
 func (a anxProvider) LoadBalancer() (cloudprovider.LoadBalancer, bool) {
+	if a.loadBalancerManager == nil {
+		return nil, false
+	}
+
 	a.providerMetrics.MarkFeatureEnabled(featureNameLoadBalancer)
 	return a.loadBalancerManager, true
 }
@@ -130,6 +134,10 @@ func (a anxProvider) Instances() (cloudprovider.Instances, bool) {
 }
 
 func (a anxProvider) InstancesV2() (cloudprovider.InstancesV2, bool) {
+	if a.instanceManager == nil {
+		return nil, false
+	}
+
 	a.providerMetrics.MarkFeatureEnabled(featureNameInstancesV2)
 	return a.instanceManager, true
 }


### PR DESCRIPTION
<!--- Please leave a helpful description of the pull request here. --->
Errors during provider initialization may result in `cloudprovider.InstancesV2` and `cloudprovider.LoadBalancer` not being available. Checks have been implemented to signal `k8s.io/cloud-provider/controllers/{service.Controller,node.Controller}` that `InstancesV2` and `LoadBalancer` are not available when initialization failed and thus prevent panics.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
