### PR TITLE
trivyignore: remove fixed CVE, added another

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,4 +1,3 @@
-# security issue in a package we indirectly depend on via kubernetes packages
-# we cannot change anything here, but this entry can be removed once the matching issue in 
-# kubernetes itself (https://github.com/kubernetes/kubernetes/issues/110338) is fixed
-CVE-2022-1996
+# security issue in a golang.org/x/net we indirectly depend on via kubernetes packages
+# entry be removed once k8s uses a fixed version -- @LittleFox94
+CVE-2022-27664


### PR DESCRIPTION
Removes a fixed CVE from trivyignore buts adds another one.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
