### PR TITLE
Panic on 401 responses from engine to slow down requests with invalid token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Changed
+* instances: panic on 401 responses from engine to slow down requests with invalid token @marioreggiori (#155)
+
 ## [1.5.1] - 2023-01-04
 
 ### Fixed

--- a/anx/provider/instances.go
+++ b/anx/provider/instances.go
@@ -31,6 +31,7 @@ func (i instanceManager) NodeAddressesByProviderID(ctx context.Context, provider
 		return nil, errors.New("empty providerId is not allowed")
 	}
 	info, err := i.VSphere().Info().Get(ctx, providerID)
+	utils.PanicIfUnauthorized(err)
 	if err != nil {
 		return nil, fmt.Errorf("could not get vm infoMock: %w", err)
 	}
@@ -57,11 +58,13 @@ func (i instanceManager) NodeAddressesByProviderID(ctx context.Context, provider
 
 func (i instanceManager) InstanceExists(ctx context.Context, node *v1.Node) (bool, error) {
 	providerID, err := i.InstanceIDByNode(ctx, node)
+	utils.PanicIfUnauthorized(err)
 	if err != nil {
 		return false, err
 	}
 
 	_, err = i.VSphere().Info().Get(ctx, providerID)
+	utils.PanicIfUnauthorized(err)
 
 	if err == nil {
 		return true, nil
@@ -76,6 +79,7 @@ func (i instanceManager) InstanceExists(ctx context.Context, node *v1.Node) (boo
 
 func (i instanceManager) InstanceShutdown(ctx context.Context, node *v1.Node) (bool, error) {
 	providerID, err := i.InstanceIDByNode(ctx, node)
+	utils.PanicIfUnauthorized(err)
 	if err != nil {
 		return false, err
 	}
@@ -97,6 +101,7 @@ func (i instanceManager) InstanceShutdown(ctx context.Context, node *v1.Node) (b
 
 func (i instanceManager) InstanceMetadata(ctx context.Context, node *v1.Node) (*cloudprovider.InstanceMetadata, error) {
 	providerID, err := i.InstanceIDByNode(ctx, node)
+	utils.PanicIfUnauthorized(err)
 	if err != nil {
 		return nil, err
 	}
@@ -135,6 +140,7 @@ func (i instanceManager) instancesByName(ctx context.Context, name string) ([]st
 	}
 
 	vms, err := i.VSphere().Search().ByName(ctx, fmt.Sprintf("%s-%s", namePrefix, name))
+	utils.PanicIfUnauthorized(err)
 
 	if err == nil && len(vms) == 0 {
 		logger.V(1).Info("Didn't find any VM by name with prefix, retrying without prefix", "prefix", namePrefix)

--- a/anx/provider/utils/utils.go
+++ b/anx/provider/utils/utils.go
@@ -2,8 +2,10 @@ package utils
 
 import (
 	"errors"
-	"go.anx.io/go-anxcloud/pkg/client"
 	"net/http"
+
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/client"
 )
 
 func IsNotFoundError(err error) bool {
@@ -18,4 +20,23 @@ func IsNotFoundError(err error) bool {
 		}
 	}
 	return false
+}
+
+// PanicIfUnauthorized panics if the provided error is due to `http.StatusUnauthorized`.
+// Use this helper to slow down Engine requests by triggering a CrashLoopBackoff.
+// NOTE: This helper only works for errors returned by go-anxcloud.
+func PanicIfUnauthorized(err error) {
+	if err == nil {
+		return
+	}
+
+	var (
+		genericAPIClientError api.HTTPError
+		legacyAPIClientError  *client.ResponseError
+	)
+
+	if (errors.As(err, &genericAPIClientError) && genericAPIClientError.StatusCode() == http.StatusUnauthorized) ||
+		(errors.As(err, &legacyAPIClientError) && legacyAPIClientError.Response.StatusCode == http.StatusUnauthorized) {
+		panic("Engine responded with http.StatusUnauthorized. Please check the configured API token.")
+	}
 }

--- a/anx/provider/utils/utils_test.go
+++ b/anx/provider/utils/utils_test.go
@@ -1,0 +1,28 @@
+package utils
+
+import (
+	"net/http"
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	"go.anx.io/go-anxcloud/pkg/api"
+	"go.anx.io/go-anxcloud/pkg/client"
+)
+
+func TestUtils(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Utility functions")
+}
+
+var _ = Describe("PanicIfUnauthorized", func() {
+	DescribeTable("Engine Errors", func(err error, expected types.GomegaMatcher) {
+		Ω(func() { PanicIfUnauthorized(err) }).Should(expected)
+	},
+		Entry("legacy API unauthorized error should panic", &client.ResponseError{Response: &http.Response{StatusCode: http.StatusUnauthorized}}, PanicWith(MatchRegexp("Engine responded with http.StatusUnauthorized."))),
+		Entry("legacy API other error should not panic", &client.ResponseError{Response: &http.Response{StatusCode: http.StatusNotFound}}, Not(Panic())),
+		Entry("generic API unauthorized error should panic", api.NewHTTPError(http.StatusUnauthorized, "FOO", nil, nil), PanicWith(MatchRegexp("Engine responded with http.StatusUnauthorized."))),
+		Entry("generic API other error should not panic", api.NewHTTPError(http.StatusNotFound, "FOO", nil, nil), Not(Panic())),
+	)
+})


### PR DESCRIPTION
To mitigate high load with unauthorized requests to the engine due to invalid API token we decided to panic on 401 HTTP responses. This causes a `CrashLoopBackoff` which slows down engine requests until problem is fixed.

<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
