### PR TITLE
Remove CVE-2022-27664 from trivyignore

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,3 +1,1 @@
-# security issue in a golang.org/x/net we indirectly depend on via kubernetes packages
-# entry be removed once k8s uses a fixed version -- @LittleFox94
-CVE-2022-27664
+


### PR DESCRIPTION
Everything updated and we do not have that CVE in our images anymore :)

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References
* #122

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
