### PR TITLE
Remove deprecated set-output in docker-scan job

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v3
 
       - name: Get Image Tag
-        run: echo "::set-output name=tag::sha-${GITHUB_SHA::7}"
+        run: echo "tag=sha-${GITHUB_SHA::7}" >>$GITHUB_OUTPUT
         shell: bash
         id: git
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Fixed
+* Fix deprecation warning for set-output in internal docker-scan job
+
 ## [1.5.3] - 2023-04-04
 
 ### Fixed


### PR DESCRIPTION
Update changelog

<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
