### PR TITLE
Fix lb reconciliation test wait timeout

### DIFF
--- a/anx/provider/loadbalancer/reconciliation/reconciliation_test.go
+++ b/anx/provider/loadbalancer/reconciliation/reconciliation_test.go
@@ -302,7 +302,7 @@ var _ = Describe("reconcile", func() {
 		})
 
 		It("waits for the resources to get ready", func() {
-			const waitTime = 2 * time.Second
+			const waitTime = 4 * time.Second
 
 			time.AfterFunc(waitTime, func() {
 				GinkgoRecover()


### PR DESCRIPTION
Wait timeout in tests was changed in #189 and caused a race condition in #192. This PR increases the wait time again.

### Checklist

* [ ] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
