### PR TITLE
Update docker base image from alpine 3.17.3 to 3.18.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+## Changed
+* Update base image to Alpine v3.18.0 @marioreggiori (#211)
+
 ## [1.5.4] - 2023-05-02
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ EXPOSE 8080
 # Hadolint wants us to pin apk packages to specific versions, mostly to make sure sudden incompatible changes
 # don't get released - for ca-certificates this only gives us the downside of randomly failing docker builds
 # hadolint ignore=DL3018
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates libcrypto3>=3.1.1-r0
 
 WORKDIR /app/
 COPY --from=builder /go/src/github.com/github.com/anexia-it/k8s-anexia-ccm/ccm .

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o ccm -ldflags "-s -w -X github.com/anexia-it/k8s-anexia-ccm/anx/provider.Version=$version"
 
-FROM alpine:3.17.3
+FROM alpine:3.18.0
 EXPOSE 8080
 
 # Hadolint wants us to pin apk packages to specific versions, mostly to make sure sudden incompatible changes


### PR DESCRIPTION
Update docker base alpine image and pin libcrypto3 to resolve CVE-2023-2650.
<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
