### PR TITLE
Implement/Fix VIP choosing mechanism when using autodiscovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Fixed
+* Fix not attempting to discover the VIP when using autodiscovery(when no prefixes are statically configure) @89q12 (#354)
+
 ## [1.5.6] - 2024-04-25
 
 ### Fixed

--- a/anx/provider/loadbalancer/address/prefix.go
+++ b/anx/provider/loadbalancer/address/prefix.go
@@ -65,6 +65,7 @@ func newPrefix(ctx context.Context, apiclient api.API, ipamClient ipam.API, iden
 	return &ret, nil
 }
 
+// this function is now the fallback if the VIP wasn't tagged...
 func (p prefix) allocateAddress(ctx context.Context, fam v1.IPFamily) (net.IP, error) {
 	if fam != p.family {
 		return nil, errFamilyMismatch


### PR DESCRIPTION
Currently when using autodiscovery we just bluntly use the first IP in the first prefix we get. This often results in returning a ServiceVM IP, this works but its not HA. Therefore when said ServiceVM is down, the LB is down as well and not traffic flows. This commit aims to fix this by first trying to discover the actual VIP in the given prefix, this requires the IP to be tagged.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
