### PR TITLE
ANXKUBE-1251: Allow setting hostname via annotation instead of IPs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+## Added
+
+* Add support for setting the hostname on services (#355, @nachtjasmin)
+
+  This is one of the changes that's required to support the PROXY protocol.
+  It is now possible to set the hostname on services via the `lbaas.anx.io/
+  load-balancer-proxy-pass-hostname` annotation. Unfortunately, proper support
+  for the PROXY protocol inside the cluster still requires operators to create
+  a support ticket, so that we (the Anexia support) can properly set the feature
+  flag in the background.
+
+  We're working hard to remove the need for this manual intervention.
+
 ### Fixed
 
 * golang/x/net: update to 0.33.0 due to CVE-2024-45338 (#372, @drpsychick)

--- a/docs/source/features.rst
+++ b/docs/source/features.rst
@@ -54,6 +54,15 @@ Like most cloud providers, we allow configuring some features via annotations on
    If this annotation is not set, ``.spec.ipFamilies`` of the service is used instead, meaning a service internally
    being dual-stack is dual-stack externally, too.
 
+#. ``lbaas.anx.io/load-balancer-proxy-pass-hostname: <RFC 1123-valid hostname>``
+
+   Allows to set the hostname for a given service instead of its IP addresses.
+   This is necessary in order to support the PROXY protocol, which otherwise
+   would be broken due to hairpinning of kube-proxy.
+
+   It can be set to any hostname that is valid according to `RFC 1123 <https://www.rfc-editor.org/rfc/rfc1123>`_.
+
+
 
 Load Balancer Discovery
 -----------------------


### PR DESCRIPTION
We want to allow setting a hostname on the LB instead of IPs, this is useful when using proxy-protocol in LBaaS.

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

<!---
Are there any other GitHub issues (open or closed) or pull requests that should be linked here? Vendor blog posts or documentation?
--->
### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
