### PR TITLE
Enable auto-merging for dependabot updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,23 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: "${{ secrets.GITHUB_TOKEN }}"
+      - name: Enable auto-merge for Dependabot PRs (only minor & patch)
+        if: "steps.metadata.outputs.update-type != 'version-update:semver-major'"
+        run: gh pr merge --auto --squash "$PR_URL"
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
To reduce the maintenance burden for me, I am now enabling auto-merging for Dependabot updates. Major updates are explicitly excluded from that and with the integration of the CI, any failing PRs are going to stay open.

If you want to support the work behind that, feel free to support the Queer Lexikon, where I copied the work from.

And as usual: be gay, do crime.

See also: https://github.com/Queer-Lexikon/regenbogenkarte/blob/98e9a16943aa4b2369bae9c6aab9765714323368/.github/workflows/dependabot-auto-merge.yml