### PR TITLE
Expose the IP together with the hostname

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Fixed
+
+* Expose both hostname and IP address, when the proxy-pass annotation is set (#378, @nachtjasmin)
+
 ## [1.5.7] - 2025-01-14
 
 ## Added


### PR DESCRIPTION
:warning: This does not work and has to be replaced with a better solution. Explanation is going to follow.

Because the IP of the LoadBalancer Service is no longer exposed, it would get harder to setup DNS records. The current workaround would be:

 * Wait for the LoadBalancer to be reconciled without the annotation.
 * Write down the IP address to configure it elsewhere.
 * Annotate the service.

This only works because there's a limitation of only one LoadBalancer per cluster at the moment. Yet, it can turn out to get problematic for any kind of automation.

As such, we're exposing the hostname together with the IP. This also removes a lot of the code introduced in #355 and moves the code to its previous implementation.

Closes: ANXKUBE-1280
See also: ANXKUBE-1251, #355

<!--- Please leave a helpful description of the pull request here. --->

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)