### PR TITLE
Handle rate limits by the Engine for LoadBalancer reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 Please add your changelog entry under this comment in the correct category (Security, Fixed, Added, Changed, Deprecated, Removed - in this order).
 -->
 
+### Fixed
+
+* Handle rate-limiting errors from the Anexia Engine (#382, @nachtjasmin)
+
 ## [1.5.7] - 2025-01-14
 
 ## Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,13 +6,13 @@ RUN go mod download
 COPY . .
 RUN CGO_ENABLED=0 go build -o ccm -ldflags "-s -w -X github.com/anexia-it/k8s-anexia-ccm/anx/provider.Version=$version"
 
-FROM alpine:3.21.0
+FROM alpine:3.21.3
 EXPOSE 8080
 
 # Hadolint wants us to pin apk packages to specific versions, mostly to make sure sudden incompatible changes
 # don't get released - for ca-certificates this only gives us the downside of randomly failing docker builds
 # hadolint ignore=DL3018
-RUN apk --no-cache add ca-certificates
+RUN apk --no-cache add ca-certificates libcrypto3
 
 WORKDIR /app/
 COPY --from=builder /go/src/github.com/github.com/anexia-it/k8s-anexia-ccm/ccm .

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/prometheus/client_model v0.6.1
 	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.9.0
-	go.anx.io/go-anxcloud v0.7.7
+	go.anx.io/go-anxcloud v0.7.8
 	gopkg.in/yaml.v3 v3.0.1
 	k8s.io/api v0.31.3
 	k8s.io/apimachinery v0.31.3

--- a/go.sum
+++ b/go.sum
@@ -184,6 +184,8 @@ github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9dec
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
 go.anx.io/go-anxcloud v0.7.7 h1:RtyqQ/Zbc62PqD7zCEikBVrWLgf6QcxVX32HokOW73c=
 go.anx.io/go-anxcloud v0.7.7/go.mod h1:OlwFe0Kf3BTp3GphivKalBiElZPgsNEEN/tMsLymbX0=
+go.anx.io/go-anxcloud v0.7.8 h1:FJk1CKBqFeBPLswSpfAGogPITkciXQ9N7Jd9adGNcH8=
+go.anx.io/go-anxcloud v0.7.8/go.mod h1:OlwFe0Kf3BTp3GphivKalBiElZPgsNEEN/tMsLymbX0=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=
 go.etcd.io/bbolt v1.3.9/go.mod h1:zaO32+Ti0PK1ivdPtgMESzuzL2VPoIG1PCQNvOdo/dE=
 go.etcd.io/etcd/api/v3 v3.5.14 h1:vHObSCxyB9zlF60w7qzAdTcGaglbJOpSj1Xj9+WGxq0=

--- a/go.sum
+++ b/go.sum
@@ -182,8 +182,6 @@ github.com/xiang90/probing v0.0.0-20190116061207-43a291ad63a2/go.mod h1:UETIi67q
 github.com/yuin/goldmark v1.1.27/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.2.1/go.mod h1:3hX8gzYuyVAZsxl0MRgGTJEmQBFcNTphYh9decYSb74=
 github.com/yuin/goldmark v1.3.5/go.mod h1:mwnBkeHKe2W/ZEtQ+71ViKU8L12m81fl3OWwC1Zlc8k=
-go.anx.io/go-anxcloud v0.7.7 h1:RtyqQ/Zbc62PqD7zCEikBVrWLgf6QcxVX32HokOW73c=
-go.anx.io/go-anxcloud v0.7.7/go.mod h1:OlwFe0Kf3BTp3GphivKalBiElZPgsNEEN/tMsLymbX0=
 go.anx.io/go-anxcloud v0.7.8 h1:FJk1CKBqFeBPLswSpfAGogPITkciXQ9N7Jd9adGNcH8=
 go.anx.io/go-anxcloud v0.7.8/go.mod h1:OlwFe0Kf3BTp3GphivKalBiElZPgsNEEN/tMsLymbX0=
 go.etcd.io/bbolt v1.3.9 h1:8x7aARPEXiXbHmtUwAIv7eV2fQFHrLLavdiJ3uzJXoI=


### PR DESCRIPTION
This should reduce the API requests expected to be unsuccessful against the engine. Unfortunately, the only tests I've done were just manual against a given cluster, due to the complexity of the given methods.

Closes: ANXKUBE-1281

### Checklist

* [x] added release notes to `Unreleased` section in [CHANGELOG.md](CHANGELOG.md)

### References

Depends on https://github.com/anexia-it/go-anxcloud/pull/438.


### Community Note
<!--- Please keep this note for the community --->
* Please vote on this issue by adding a 👍 [reaction](https://blog.github.com/2016-03-10-add-reactions-to-pull-requests-issues-and-comments/) to the original issue to help the community and maintainers prioritize this request
